### PR TITLE
[/post/{id}, /post/{id}/edit] PostIdEdit 화면 기본 구성 완료

### DIFF
--- a/src/components/common/Buttons/DeleteMessageButton.js
+++ b/src/components/common/Buttons/DeleteMessageButton.js
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 // import { deleteMessages } from '../../../api/DeleteApi';
 
 function DeleteMessageButton() {
   const navigate = useNavigate();
   const { id: recipientID } = useParams();
+  const location = useLocation();
+  const isEditRoute = location.pathname.includes('/edit');
 
   // temp messageID(parameter로 messageID를 받으면 해당 공간에 messageID 넣기)
   // const handleButtonClick = async () => {
@@ -17,14 +19,17 @@ function DeleteMessageButton() {
   };
 
   return (
-    <Button onClick={handleButtonClick}>
+    <Button onClick={handleButtonClick} isDisplay={isEditRoute}>
       <DeleteImg src="/img/deleted.svg" alt="삭제" />
     </Button>
   );
 }
 
 const Button = styled.button`
-  display: flex;
+  position: absolute;
+  right: 24px;
+  display: ${({ isDisplay }) => (isDisplay ? 'block' : 'none')};
+  /* display: flex; */
   padding: 6px;
   justify-content: center;
   align-items: center;

--- a/src/components/post/Card.jsx
+++ b/src/components/post/Card.jsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import DeleteMessageButton from '../common/Buttons/DeleteMessageButton';
 
 const Text = css`
   font-family: Pretendard;
@@ -53,6 +54,7 @@ const UserPicture = styled.img`
 const UserText = styled.div`
   ${Text}
   display: block;
+  position: relative;
   color: #000;
   font-size: 20px;
   font-weight: 400;
@@ -138,6 +140,7 @@ function Card({
             From. <UserName>{name}</UserName>
             <UserState state={userState}>{userState}</UserState>
           </UserText>
+          <DeleteMessageButton />
         </UserInfo>
         <SplitHorizontal />
         <CardContentText>{cardContent}</CardContentText>

--- a/src/components/post/card/CardItems.jsx
+++ b/src/components/post/card/CardItems.jsx
@@ -1,0 +1,23 @@
+import Card from '../Card';
+
+function CardItems({ data }) {
+  return (
+    // eslint-disable-next-line
+    <>
+      {/* refactoring : undefined 처리 최적화 */}
+      {data.recentMessages &&
+        data.recentMessages.map((message) => (
+          <Card
+            key={message.id}
+            src={message.profileImageURL}
+            name={message.sender}
+            userState={message.relationship}
+            cardContent={message.content}
+            cardCreatedAt={message.createdAt}
+          />
+        ))}
+    </>
+  );
+}
+
+export default CardItems;

--- a/src/pages/PostId.jsx
+++ b/src/pages/PostId.jsx
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
-// eslint-disable-next-line
-import { Link, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import Header from '../components/common/Header';
 import SubHeader from '../components/post/SubHeader';
-import Card, { CardContentWrapper } from '../components/post/Card';
+import { CardContentWrapper } from '../components/post/Card';
 import { getRecipientData } from '../api/GetApi';
 import EditButton from '../components/common/Buttons/EditButton';
+import CardItems from '../components/post/card/CardItems';
 
-const HeaderWrapper = styled.div`
+export const HeaderWrapper = styled.div`
   position: sticky;
   top: 0;
   left: 0;
@@ -26,7 +26,7 @@ const userBackgroundColors = {
   blue: { background: 'var(--blue200)' },
 };
 
-const PostIdWrapper = styled.div`
+export const PostIdWrapper = styled.div`
   background-color: ${(props) => {
     const colorInfo = userBackgroundColors[props.color];
     return colorInfo && colorInfo.background;
@@ -39,7 +39,7 @@ const PostIdWrapper = styled.div`
   min-height: 100vh;
 `;
 
-const ButtonSection = styled.div`
+export const ButtonSection = styled.div`
   display: flex;
   margin: 63px auto 11px;
   justify-content: end;
@@ -47,7 +47,7 @@ const ButtonSection = styled.div`
 `;
 
 // eslint-disable-next-line
-const CardWrapper = styled.div`
+export const CardWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   max-width: 1200px;
@@ -83,6 +83,7 @@ const PlusIcon = styled.div`
 `;
 
 function PostId() {
+  const navigate = useNavigate();
   const { id } = useParams();
   const [data, setData] = useState({});
   const handleIdData = async () => {
@@ -111,21 +112,12 @@ function PostId() {
         <EditButton />
       </ButtonSection>
       <CardWrapper>
-        <CardAdd>
+        <CardAdd onClick={() => navigate(`/post/${data.id}/message`)}>
           <PlusIcon>
             <img src="/img/plusIcon.svg" alt="" />
           </PlusIcon>
         </CardAdd>
-        {data.recentMessages &&
-          data.recentMessages.map((message) => (
-            <Card
-              src={message.profileImageURL}
-              name={message.sender}
-              userState={message.relationship}
-              cardContent={message.content}
-              cardCreatedAt={message.createdAt}
-            />
-          ))}
+        <CardItems data={data} />
       </CardWrapper>
     </PostIdWrapper>
   );

--- a/src/pages/PostId.jsx
+++ b/src/pages/PostId.jsx
@@ -42,6 +42,8 @@ export const PostIdWrapper = styled.div`
 export const ButtonSection = styled.div`
   display: flex;
   margin: 63px auto 11px;
+  max-width: 1200px;
+  gap: 10px;
   justify-content: end;
   align-items: center;
 `;

--- a/src/pages/PostIdEdit.jsx
+++ b/src/pages/PostIdEdit.jsx
@@ -1,14 +1,49 @@
-import DeleteMessageButton from '../components/common/Buttons/DeleteMessageButton';
+import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import DeleteRecipientButton from '../components/common/Buttons/DeleteRecipientButton';
+import { getRecipientData } from '../api/GetApi';
+import {
+  PostIdWrapper,
+  HeaderWrapper,
+  ButtonSection,
+  CardWrapper,
+} from './PostId';
+import Header from '../components/common/Header';
+import SubHeader from '../components/post/SubHeader';
+import CardItems from '../components/post/card/CardItems';
 
 function PostIdEdit() {
+  const { id } = useParams();
+  const [data, setData] = useState({});
+  const handleIdData = async () => {
+    try {
+      const result = await getRecipientData(id);
+      setData(result);
+    } catch (error) {
+      // console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    handleIdData();
+  }, []);
+
   return (
-    <div>
-      <DeleteMessageButton />
-      <DeleteMessageButton />
-      <DeleteMessageButton />
-      <DeleteRecipientButton />
-    </div>
+    <PostIdWrapper color={data.backgroundColor} image={data.backgroundImageURL}>
+      <HeaderWrapper>
+        <Header />
+      </HeaderWrapper>
+      <SubHeader
+        name={data ? data.name : ''}
+        peopleNum={data ? data.messageCount : 0}
+      />
+      <ButtonSection>
+        <DeleteRecipientButton />
+      </ButtonSection>
+      <CardWrapper>
+        <CardItems data={data} />
+      </CardWrapper>
+    </PostIdWrapper>
   );
 }
 


### PR DESCRIPTION
## 변경 사항
- PostIdEdit 기본 구성 완료 (Card 마다 delete 버튼 배치, 수정하기 버튼 배치)
- Card를 공통적으로 받아올 수 있도록 component refactoring 진행
- '+' 카드 눌러서 /post/{id}/message 화면으로  이동하도록 구현

## 관련 이슈
#7 