### PR TITLE
[Modal, Refactor] message 수정 버튼 위치 이동 및 ModalWindow 불필요한 코드 삭제

### DIFF
--- a/src/components/common/Buttons/EditMessageButton.js
+++ b/src/components/common/Buttons/EditMessageButton.js
@@ -20,6 +20,9 @@ const Button = styled.button`
   gap: 10px;
   border-radius: 12px;
   background: var(--${({ disabled }) => (disabled ? 'gray300' : 'purple600')});
+  position: absolute;
+  top: 36px;
+  right: 36px;
 
   color: var(--white);
   text-align: center;

--- a/src/components/common/ModalWindow.jsx
+++ b/src/components/common/ModalWindow.jsx
@@ -54,24 +54,6 @@ const ModalContents = styled.div`
 
 function ModalWindow({ children }) {
   const [modal, setModal] = useState(true);
-  // const ref = useRef();
-
-  // const handleOutsideClick = (e) => {
-  //   if (modal && (!ref.current || !ref.current.contains(e.target))) {
-  //     setModal(false);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   if (modal) {
-  //     window.addEventListener('click', handleOutsideClick);
-  //   } else {
-  //     window.removeEventListener('click', handleOutsideClick);
-  //   }
-  //   return () => {
-  //     window.removeEventListener('click', handleOutsideClick);
-  //   };
-  // }, [modal]);
 
   const handleClickBtn = (e) => {
     e.preventDefault();

--- a/src/components/modal/CardModal.jsx
+++ b/src/components/modal/CardModal.jsx
@@ -47,11 +47,15 @@ function CardModal({
             From. <UserName>{name}</UserName>
             <UserState $state={userState}>{userState}</UserState>
           </UserText>
-          <CardCreatedAt>
-            {`${createdDays.getFullYear()}. ${
-              createdDays.getMonth() + 1
-            }. ${createdDays.getDate()}`}
-          </CardCreatedAt>
+          {isEditRoute ? (
+            <EditMessageButton messageID={id} />
+          ) : (
+            <CardCreatedAt>
+              {`${createdDays.getFullYear()}. ${
+                createdDays.getMonth() + 1
+              }. ${createdDays.getDate()}`}
+            </CardCreatedAt>
+          )}
         </UserInfo>
         <SplitHorizontal />
         <CardContentTextContainer>
@@ -61,7 +65,6 @@ function CardModal({
           />
         </CardContentTextContainer>
       </CardContent>
-      {isEditRoute ? <EditMessageButton messageID={id} /> : ''}
     </Container>
   );
 


### PR DESCRIPTION
## 변경 사항
- /edit 에서 card 클릭 시 나오는 modal에 대하여, 기존의 게시 시간이 위치하였던 공간에 '수정하기' 버튼이 위치하도록 변경
- ModalWindow에서 불필요하였던 code 삭제
- CardModal에서 /edit의 위치일 경우 수정하기 버튼, /post/{id} 위치일 경우 생성 시간이 표시되도록 코드 구성 변경

## 관련 이슈
#1 #7 #61 