### PR TITLE
[/post/{id}] 모달의 텍스트 표현 재적용

### DIFF
--- a/src/styles/reset.jsx
+++ b/src/styles/reset.jsx
@@ -41,6 +41,31 @@ const reset = css`
   input[type='search']::-webkit-search-results-decoration {
     display: none;
   }
+
+  
+.align-right {
+  text-align: right;
+}
+
+.align-center {
+  text-align: center;
+}
+
+.align-justify {
+  text-align: justify;
+}
+
+.size-huge {
+  font-size: 2.5em;
+}
+
+.size-large {
+  font-size: 1.5em;
+}
+
+.size-small {
+  font-size: 0.75em;
+}
 `;
 
 export default reset;


### PR DESCRIPTION
reset.jsx를 설정하면서 삭제되었던 css 코드를 재적용시켰습니다.