### PR TITLE
Fix: URL 복사 netlify 주소로 변경

### DIFF
--- a/src/components/modal/ShareToggle.jsx
+++ b/src/components/modal/ShareToggle.jsx
@@ -48,7 +48,7 @@ function ShareToggle({ setIsKakaoOpen, setIsUrlCopy }) {
   };
 
   const location = useLocation();
-  const baseUrl = 'http://localhost:3000';
+  const baseUrl = 'https://testrollingforteam.netlify.app';
 
   return (
     <ShareBox>


### PR DESCRIPTION
## 변경 사항
- 태훈님이 보내주신 주소로 URL 복사하는 주소 변경했습니다. 주소 이름 똑같이 다시 배포해주시면 될 것 같아요!

## 관련 이슈
#7 